### PR TITLE
Allow circular data structures in state (fixes #22)

### DIFF
--- a/src/generate/example.js
+++ b/src/generate/example.js
@@ -4,7 +4,7 @@ import _ from 'lodash/fp.js';
 import { log } from '../logger.js';
 
 export const generateExample = (config,example) => {
-    log.debug('generateExample config: '+JSON.stringify(config)+' example: '+JSON.stringify(example));
+    log.debug(`generateExample config: ${JSON.stringify(config)} example: ${JSON.stringify(example)}`);
     var tests = '';
 
     const steps = _.has('background.steps',example) ? _.concat(example.background.steps,example.steps) : example.steps;

--- a/src/generate/examples.js
+++ b/src/generate/examples.js
@@ -17,7 +17,7 @@ const createParameterMap = (parameters,values) => {
 const generateAllTests = (steps,parameters,parameterValues,tags) => {
     const allTests = _.reduce((allTests,values) => {
         const parameterMap = createParameterMap(parameters,values);
-        log.debug('parameterMap : '+JSON.stringify(parameterMap));
+        log.debug(`parameterMap : ${JSON.stringify(parameterMap)}`);
 
         const tests = generateTests(steps,parameterMap,tags,'    ');
 
@@ -30,13 +30,12 @@ const generateAllTests = (steps,parameters,parameterValues,tags) => {
 }
 
 export const generateExamples = (config,steps,examplesStatement) => {
-    log.debug('generateExamples steps:'+JSON.stringify(steps)+' examples: '+JSON.stringify(examplesStatement));
+    log.debug(`generateExamples steps:${JSON.stringify(steps)} examples: ${JSON.stringify(examplesStatement)}`);
 
     const parameters = _.head(examplesStatement.dataTable);
     const parameterValues = _.tail(examplesStatement.dataTable);
 
-    log.debug('generateExamples parameters:'+JSON.stringify(parameters)+' parameterValues: '+
-              JSON.stringify(parameterValues));
+    log.debug(`generateExamples parameters:${JSON.stringify(parameters)} parameterValues: ${JSON.stringify(parameterValues)}`);
 
     const skip = shouldSkip(config,examplesStatement.tags) ? '.skip' : '';
 

--- a/src/generate/rule.js
+++ b/src/generate/rule.js
@@ -4,7 +4,7 @@ import { escape, shouldSkip } from './util.js';
 import { log } from '../logger.js';
 
 export const generateRule = (config,rule) => {
-    log.debug('generateRule config: '+JSON.stringify(config)+' rule: '+JSON.stringify(rule));
+    log.debug(`generateRule config: ${JSON.stringify(config)} rule: ${JSON.stringify(rule)}`);
     
     const examplesCode = _.reduce((examplesCode,example) => {
         return examplesCode + generateExample(config,example);

--- a/src/generate/tests.js
+++ b/src/generate/tests.js
@@ -4,7 +4,7 @@ import { parameterizeText } from '../parameterize.js';
 import { log } from '../logger.js';
 
 export const generateTests = (steps,parameterMap,tags,extraIndent) => {
-    log.debug('generateTests steps : '+JSON.stringify(steps));
+    log.debug(`generateTests steps : ${JSON.stringify(steps)}`);
     const tagsStr = JSON.stringify(tags);
     const indent = extraIndent ? extraIndent : '';
     let tests = `

--- a/src/generate/util.js
+++ b/src/generate/util.js
@@ -4,6 +4,6 @@ import { log } from '../logger.js';
 export const escape = (str) => str.replace(/'/g,"\\'");
 export const shouldSkip = (config,tags) => {
     const result = !config.tagsFunction(tags);
-    log.debug('shouldSkip? '+result+' tags: '+JSON.stringify(tags));
+    log.debug(`shouldSkip? ${result} tags: ${JSON.stringify(tags)}`);
     return result;
 }

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -23,11 +23,11 @@ const hookNames = {
 
 const applyHooks = async (hooksName,state,tags) => {
     const hooks = allHooks[hooksName];
-    log.debug('applyHooks: '+hooksName+' state: '+JSON.stringify(state));
+    log.debug({ state }, `applyHooks: ${hooksName}`);
     for (let i = 0; i < hooks.length; i++) {
         let hook = hooks[i];
         
-        log.debug('applyHooks name: '+hook.name+' state: '+JSON.stringify(state));
+        log.debug({ state }, `applyHooks name: ${hook.name}`);
         
         const result = hook.tagsFunction(tags);
         
@@ -35,8 +35,7 @@ const applyHooks = async (hooksName,state,tags) => {
         if (result) {
             const origState = state;
             state = await hook.f(state);
-            log.info(hookNames[hooksName]+'(\''+hook.name+'\') ('+JSON.stringify(origState)+') => '+
-                     JSON.stringify(state));
+            log.info({ state, origState }, `${hookNames[hooksName]}('${hook.name}')`);
         }
     }
     return state;
@@ -55,7 +54,7 @@ const addHook = (hooksName,opts,f) => {
 
     opts = _.set('tagsFunction',tagsFunction(opts.tags),opts);
     
-    log.debug('addHook hooksName: '+hooksName+' name: '+opts.name);
+    log.debug(`addHook hooksName: ${hooksName} name: ${opts.name}`);
     allHooks[hooksName] = _.concat(allHooks[hooksName],opts);
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -42,16 +42,14 @@ export const When = addStepDefinition;
 export const Then = addStepDefinition;
 
 export const Test = (state,step) => {
-    log.debug('Test step: '+JSON.stringify(step)+' state:'+JSON.stringify(state));
+    log.debug({ step, state }, 'Test step');
     const stepDefinitionMatch = findStepDefinitionMatch(step);
 
     const extraData = step.dataTable ? step.dataTable : (step.docString ? step.docString.text : null );
 
     const newState = stepDefinitionMatch.stepDefinition.f(state,stepDefinitionMatch.parameters,extraData);
-    log.info(step.type.name+'(\''+stepDefinitionMatch.stepDefinition.expression+'\') ('+
-             JSON.stringify(state)+','+JSON.stringify(stepDefinitionMatch.parameters)+','+JSON.stringify(extraData)+
-             ') => '+JSON.stringify(newState));
-    log.debug('Test newState: '+JSON.stringify(newState));
+    log.info({ state, newState, extraData, parameters: stepDefinitionMatch.parameters }, `${step.type.name}('${stepDefinitionMatch.stepDefinition.expression}')`);
+    log.debug({ newState }, 'Test newState');
 
     return newState;
 };
@@ -75,13 +73,13 @@ export default function vitestCucumberPlugin() {
 
             config = _.set('tagsFunction',tagsFunction(_.get('tags',config)),config);
 
-            log.debug('config: '+JSON.stringify(config));
+            log.debug({ config }, 'config');
         },
         transform : async (src,id) => {
             if (featureRegex.test(id)) {
                 const code = await compileFeatureToJS(config,src);
 
-                log.debug('transform '+id+' -> '+code);
+                log.debug(`transform ${id} -> ${code}`);
 
                 return {
                     code

--- a/src/parse.js
+++ b/src/parse.js
@@ -5,13 +5,13 @@ import { log } from './logger.js';
 export const parse = (src) => {
     const parser = new nearley.Parser(nearley.Grammar.fromCompiled(gherkin));
 
-    log.debug('parsing src: '+src);
+    log.debug(`parsing src: ${src}`);
     parser.feed(src);
 
     if (parser.results.length == 0) {
         throw new Error('Unexpected end of file');
     }
-    log.debug('parsing result: '+JSON.stringify(parser.results));
+    log.debug({ results: parser.results }, 'parsing result');
     if (parser.results.length > 1) {
         throw new Error('Ambiguous parsing: '+parser.results.length);
     }

--- a/src/steps.js
+++ b/src/steps.js
@@ -13,7 +13,7 @@ const typeName = {
 const expressionFactory = new ExpressionFactory(new ParameterTypeRegistry());
 
 export const addStepDefinition = (expression,f) => {
-    log.debug('addStepDefinition expression: '+JSON.stringify(expression));
+    log.debug({ expression }, 'addStepDefinition expression');
     const cucumberExpression = expressionFactory.createExpression(expression);
     steps = _.concat(steps,{ expression, f, cucumberExpression });
 }

--- a/src/tags.js
+++ b/src/tags.js
@@ -8,7 +8,7 @@ const parseTagsExpression = (tagsExpression) => {
 
     tagsExpression += '\n';
     parser.feed(tagsExpression);
-    log.debug('parseTagsExpression expression: \''+tagsExpression+'\' results: '+JSON.stringify(parser.results));
+    log.debug({ results: parser.results }, `parseTagsExpression expression: '${tagsExpression}'`);
 
     if (parser.results.length == 0) {
         throw new Error('Unexpected end of expression');
@@ -23,10 +23,10 @@ const parseTagsExpression = (tagsExpression) => {
 
 const createFunction = (e) => {
     if (_.isString(e)) {
-        log.debug('createFunction tag: '+e);
+        log.debug(`createFunction tag: ${e}`);
         return (tags) => {
             const result = _.find((tag) => tag == e,tags);
-            log.debug('tagsExpression tag: '+e+' tags: '+JSON.stringify(tags)+' match? '+result);
+            log.debug(`tagsExpression tag: ${e} tags: ${JSON.stringify(tags)} match? ${result}`);
             return result;
         }
     }
@@ -36,12 +36,12 @@ const createFunction = (e) => {
     }
 
     if (e.operator == 'not') {
-        log.debug('createFunction not '+JSON.stringify(e.expression));
+        log.debug(`createFunction not ${JSON.stringify(e.expression)}`);
         const f = createFunction(e.expression);
         return (tags) => !f(tags);
     }
 
-    log.debug('createFunction '+JSON.stringify(e.left)+' '+e.operator+' '+JSON.stringify(e.right));
+    log.debug(`createFunction ${JSON.stringify(e.left)} ${e.operator} ${JSON.stringify(e.right)}`);
     const l = createFunction(e.left);
     const r = createFunction(e.right);
     


### PR DESCRIPTION
By utilising Pino's built-in support for logging circular data structures we can now handle any type of state, including states with circular data structures